### PR TITLE
Retira sessao de patrocínio e item "submissao" do navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
             <a class="nav-link" href="#evento">Sobre</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#submissao">Submissões</a>
+            <a class="nav-link" href="#programacao">Programação</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="#codigoconduta">Código de conduta</a>
@@ -100,7 +100,7 @@
     </div>
   </div>
 
-    <div id=submissao class="anchor"></div>
+    <div id=programacao class="anchor"></div>
     <div class="d-md-flex flex-md-equal w-100 my-md-3 pl-md-3">
       <div style="background-color:#e3e5e6c2" class="col-md-6 text-center overflow-hidden">
         <div class="my-3 p-3">

--- a/index.html
+++ b/index.html
@@ -34,9 +34,6 @@
             <a class="nav-link" href="#submissao">Submissões</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#patrocinio">Patrocínio</a>
-          </li>
-          <li class="nav-item">
             <a class="nav-link" href="#codigoconduta">Código de conduta</a>
           </li>
           <li class="nav-item">
@@ -91,9 +88,11 @@
           <p class="lead">Feita pela comunidade para a comunidade, tem o objetivo de difundir
           a linguagem, disseminar conhecimento, promover a troca de experiências e manter a
           comunidade crescendo igualmente em público e impacto social.
-          Este ano, em caráter de exceção devido à pandemia de covid-19, a Python Brasil será
+          Este ano, em caráter de exceção devido à pandemia de Covid-19, a Python Brasil será
           realizada remotamente, organizada por um time distribuído no Brasil e no mundo, a fim
           de prosseguir com o seu objetivo de disseminar conhecimento e aproximar pessoas.</p>
+          <p>Nosso Plano de Patrocínio está disponível em (<a style="color:#476088" href="/plano-patrocinio-pybr2021.pdf">pt-br</a> / <a style="color:#476088" href="/sponsorship-plan-pybr2021.pdf">en</a>).
+          </p>
         </div>
         <img style="z-index: 32; left: 30px; position: relative;" alt="bottom image" src="assets/img/section_2/sec3_1.png">
         <img style="z-index: 32; left: 150px; position: relative;" alt="bottom image" src="assets/img/section_0/eclipse-top-2.png">
@@ -120,31 +119,9 @@
       </div>
     </div>
 
-    <div id=patrocinio class="anchor"></div>
-    <div class="d-md-flex flex-md-equal w-100 my-md-3 pl-md-3">
-      <div class="mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
-        <img style="z-index: 32; left: -150px; position: relative;" alt="bottom image" src="assets/img/section_2/sec2_2.png">
-        <div class="my-3 p-3 text-center">
-          <h4>Saiba mais sobre no nosso <br>
-          <strong>Plano de Patrocínio! <br>(<a style="color:#476088" href="/plano-patrocinio-pybr2021.pdf">pt-br</a>
-            / <a style="color:#476088" href="/sponsorship-plan-pybr2021.pdf">en</a>)
-          </strong></h4>
-        </div>
-        <img style="z-index: 32; left: 110px; position: relative;" alt="bottom image" src="assets/img/section_0/eclipse-top-3.png">
-      </div>
-
-      <div style="background-color:#fab8c5" class="text-center overflow-hidden">
-        <div class="my-3 py-3">
-          <h4 class="lead font-weight-bold my-3 p-3" style="color:#476088">Patrocinadoras do evento</h4>
-          <h2 class="display-5 font-weight-bold">Venha ser uma <br> empresa patrocinadora do evento</h2>
-          <br>
-        </div>
-      </div>
-    </div>
-
     <div id=codigoconduta class="anchor"></div>
     <div class="d-md-flex flex-md-equal w-100 my-md-3 pl-md-3">
-      <div style="background-color:#e3e5e6c2" class="col-md-6 text-center overflow-hidden">
+      <div class="col-md-6 text-center overflow-hidden">
         <div class="my-3 p-3">
           <h2 class="display-5 my-3 p-3 " style="color: #476088;">Todas as pessoas que participam da Python Brasil devem concordar
           em seguir o nosso Código de Conduta.
@@ -194,8 +171,8 @@
         </div>
       </div>
     </div>
-
-    <footer class="container py-5">
+    <div class="division"></div>
+    <footer class="container py-5">  
       <div class="row text-center" style="display: block;">
         <h6>Python Brasil é uma conferência sem fins lucrativos dirigida por voluntários para promover
         a linguagem de programação Python de código aberto.</h6>


### PR DESCRIPTION
Retira sessão dedicada a patrocínio e realoca link para Plano de Patrocínio para a sessão "Sobre". Este link foi mantido visando a permanencia em local explícito da documentação do evento. 

![image](https://user-images.githubusercontent.com/30605862/133474826-19dc845b-aeb7-4c49-9292-877228e2055b.png)

No navbar foi substituído o item "Submissão" por "Programação".
![image](https://user-images.githubusercontent.com/30605862/133474950-ab6fc6dd-ed55-4f4b-ae9e-9c7b69bbbba0.png)
