### PR TITLE
Remove "recursos" do menu e diminui o espaço entre os items

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,9 +43,6 @@
             <a class="nav-link" href="./doacoes.html">Doações</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#recursos">Recursos</a>
-          </li>
-          <li class="nav-item">
             <a class="nav-link" href="#codigoconduta">Código de conduta</a>
           </li>
         </ul>

--- a/style.css
+++ b/style.css
@@ -18,7 +18,7 @@ a{
 }
 
 .nav-item {
-  margin: 0 20px;
+  margin: 0 15px;
   font-weight: 600;
 }
 


### PR DESCRIPTION
## Issues relacionadas

- closes #43  

## Descrição

Remove o item "Recursos" do menu, acho até que já havíamos removido antes, deve ter voltado em algum PR rs. E diminui um pouco o espaçamento entre os itens do menu.

## Preview

![Screen Shot 2021-10-06 at 18 32 33](https://user-images.githubusercontent.com/6524275/136286339-de6ec4ad-e66a-46b1-85de-adf7507daa65.png)
