### PR TITLE
Corrige ordem dos eventos no calendário

### DIFF
--- a/pages/grade/index.js
+++ b/pages/grade/index.js
@@ -10,9 +10,8 @@ function convertTZ(date, tzString) {
 }
 
 function groupEvents(events) {
-  events.sort((a, b) => {
-    return a.start.dateTime > b.start.dateTime
-  });
+  events.sort((a, b) => a.start.dateTime < b.start.dateTime ? -1 : 1);
+
   var groupedEvents = {}
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   for (var event of events) {


### PR DESCRIPTION
Retornar booleanos na função de comparação do `array.sort(f)` não funciona direto porque o JavaScript espera 3 comportamentos diferentes:

Comparando `a` e `b`:
- Se a função retornar um valor maior que zero: `b, a`
- Se a função retornar um valor menor que zero: `a, b`
- Se a função retornar zero, `a` é considerado igual a `b`: `a, b`

No nosso caso:
- `2021-10-11T22:00:00Z > 2021-10-11T19:40:00Z == true`
  - JS interpreta `true` como igual a `1`
  - Ordem final fica `2021-10-11T19:40:00Z`, `2021-10-11T22:00:00Z`
- `2021-10-11T18:00:00Z > 2021-10-11T18:50:00Z == falso`, 
  - JS interpreta `false` como igual a `0` e acaba considerando os dois como iguais

Por algum motivo, a função no Firefox Nightly 94.0a1 e em alguma versão do Safari funcionam com booleanos.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description