### PR TITLE
Lives do YouTube de segunda-feira

### DIFF
--- a/public/doacoes.html
+++ b/public/doacoes.html
@@ -46,7 +46,7 @@
             <a class="nav-link" href="index.html#codigoconduta">Código de conduta</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="./perguntas-frequentes.html">Perguntas frequentes</a>
+            <a class="nav-link" href="./perguntas-frequentes.html">FAQ</a>
           </li>
         </ul>
       </div>

--- a/public/index.html
+++ b/public/index.html
@@ -46,7 +46,7 @@
             <a class="nav-link" href="#codigoconduta">Código de conduta</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="./perguntas-frequentes.html">Perguntas frequentes</a>
+            <a class="nav-link" href="./perguntas-frequentes.html">FAQ</a>
           </li>
         </ul>
       </div>

--- a/public/index.html
+++ b/public/index.html
@@ -79,7 +79,46 @@
         </div>
       </div>
     </div>
-    <br>
+
+    <div id="lives" class="anchor">
+      <div class="mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">
+        <h2 class="display-5 text-center">Assista agora</h2>
+      </div>
+      <div class="lives text-center overflow-hidden" style="background: #f4f4f4;">
+        <div>
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/HqRDZ5unNuo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <p>Roda de Conversa: AfroPython</p>
+        </div>
+      </div>
+      <div class="lives text-center overflow-hidden">
+        <div class="talks">
+          <iframe src="https://www.youtube.com/embed/qu85TN0Ljok" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <p>Trilha: Timnit Gebru</p>
+        </div>
+        <div class="talks">
+          <iframe src="https://www.youtube.com/embed/c-ytboo__JI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <p>Trilha: Bonnie Prado Pinto</p>
+        </div>
+        <div class="talks">
+          <iframe src="https://www.youtube.com/embed/s7B8Cd02MF8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <p>Trilha: Shirley Ann Jackson</p>
+        </div>
+        <div class="talks">
+          <iframe src="https://www.youtube.com/embed/lsrVtD5qaW4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <p>Trilha: Marie Van Brittan Brown</p>
+        </div>
+        <div class="talks">
+          <iframe src="https://www.youtube.com/embed/7Rgz3rnVPR4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <p>Trilha: Angelica Ross</p>
+        </div>
+      </div>
+      <div class="lives text-center overflow-hidden" style="background: #f4f4f4;">
+        <div>
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/-OMV8DEEN8E" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <p>Keynote: Kizzy Terra e Hallison Paz</p>
+        </div>
+      </div>
+    </div>
 
     <div id=evento class="anchor">
     <div class="bg-white mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden">

--- a/public/perguntas-frequentes.html
+++ b/public/perguntas-frequentes.html
@@ -46,7 +46,7 @@
             <a class="nav-link" href="./index.html#codigoconduta">Código de conduta</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="./perguntas-frequentes.html">Perguntas frequentes</a>
+            <a class="nav-link" href="./perguntas-frequentes.html">FAQ</a>
           </li>
         </ul>
       </div>
@@ -128,7 +128,7 @@
         <br>
     </div>
   </div>
-    
+
     <footer class="container py-5">
       <div class="row text-center" style="display: block;">
         <h6>Python Brasil é uma conferência sem fins lucrativos dirigida por voluntários para promover

--- a/public/style.css
+++ b/public/style.css
@@ -18,7 +18,7 @@ a{
 }
 
 .nav-item {
-  margin: 0 15px;
+  margin: 0 9px;
   font-weight: 600;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -162,6 +162,35 @@ nav.shift ul li a:hover:after {
 
 
 /*
+ * Lives
+ */
+ .lives {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  flex-flow: wrap;
+  padding: 20px 0;
+}
+
+.lives .talks {
+  margin: 20px;
+  display: block;
+}
+
+.lives .talks iframe {
+  width: 560px;
+  height: 315px;
+}
+
+@media screen and (min-width: 720px) {
+  .lives .talks iframe {
+    width: 300px;
+    height: 175px;
+  }
+}
+
+
+/*
  * Keynotes
  */
 .keynoter {


### PR DESCRIPTION
## Issues relacionadas

- closes partially #15 

## Descrição

Adiciona os iframes das lives de segunda-feira: roda de conversa, trilhas e keynote. No caso, precisaremos fazer um novo PR para atualizar os links para terça e assim sucessivamente.

Aproveitei o PR para corrigir o menu principal, evitando quebra de linha.